### PR TITLE
fix failure to locating settings in docker-compose setup

### DIFF
--- a/settings/search-settings.py
+++ b/settings/search-settings.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from urllib.parse import urlparse
+from .common import *
 
 base_dir = Path(__file__).absolute().parent.parent.parent.parent
 

--- a/settings/search.env
+++ b/settings/search.env
@@ -1,3 +1,4 @@
 DOCKER_HOOVER_SEARCH_SECRET_KEY=eichahchaquoo1jooj5ha9ahnienoomeeHeizei1jee2ka3Keihiqueedohge4Raxaibeiboeyai0cha4odieph9Ohph1bohph6m
 DOCKER_HOOVER_SEARCH_DEBUG=on
 DOCKER_HOOVER_BASE_URL=http://localhost
+DJANGO_SETTINGS_MODULE=hoover.site.settings.local


### PR DESCRIPTION
Hoover search stopped working in docker-setup after some changes related to nomad support. This PR makes hoover search load the settings from the proper module.